### PR TITLE
fix(build): include TypeScript declaration files in published package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
       - run: npm install -g pnpm
       - run: pnpm install
       - run: pnpm run build:minified
+      - run: pnpm run build:types
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "scripts": {
     "clean": "shx rm -rf _bundles lib lib-esm",
     "build": "tsc --declaration",
+    "build:types": "tsc -p tsconfig.build.json",
     "build:minified": "webpack",
     "lint": "eslint 'src/**'",
     "lint:fix": "eslint 'src/**' --fix",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,19 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "./dist",
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "sourceMap": false,
+    "inlineSources": false
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "**/*.spec.ts",
+    "**/experiments/*"
+  ]
+}


### PR DESCRIPTION
# Description

The release workflow only runs `pnpm run build:minified` (webpack) before `npm publish`. Webpack bundles the JS into `dist/index.js`, but `ts-loader` does not emit declaration files. As a result, the package published to npm has been missing the `.d.ts` files that `package.json` advertises through its `types` field (`dist/index.d.ts`), so consumers get no type information.

The `tsc --declaration` build that would generate the declarations was never part of the publish pipeline.

This PR generates the declaration files at publish time and places them exactly where the `types` field points.

- Add `tsconfig.build.json` that emits declarations only (`emitDeclarationOnly: true`) with `rootDir: "src"`, so `index.d.ts` lands at `dist/index.d.ts` (matching the `types` field) instead of `dist/src/index.d.ts`.
- Add a `build:types` script running `tsc -p tsconfig.build.json`.
- Run `build:types` after `build:minified` and before `npm publish` in the release workflow, so the bundle and the declarations end up side by side in `dist/`.

No public API or runtime behavior changes — this only affects what gets shipped to npm.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Ran `pnpm run build:types` locally and confirmed the emitted files:

```
dist/index.d.ts        <- matches the "types" field
dist/types.d.ts
dist/encrypt-storage.d.ts
dist/async-encrypt-storage.d.ts
dist/utils.d.ts
dist/errors/index.d.ts
dist/errors/invalid-secret-key-error.d.ts
```

- [x] Confirmed `.npmignore` does not exclude `.d.ts` files, so they will be included in the published tarball.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)